### PR TITLE
Show turtle despite of "height" used -- fix for missing turtle image in 3D mode

### DIFF
--- a/src/pyplasm/fenvs.py
+++ b/src/pyplasm/fenvs.py
@@ -9332,10 +9332,7 @@ def NCLabTurtleShow(turtle, layer=0, dots=True):
     image = PRISM(image, NCLAB_TURTLE_IMAGE_H)
     canvas = PRISM(canvas, NCLAB_TURTLE_TRACE_H)
     if turtle.isvisible:
-        if not turtle.heightused:
-            SHOW(image, canvas, trace)
-        else:
-            SHOW(canvas, trace)
+        SHOW(image, canvas, trace)
     else:
         SHOW(canvas, trace)
 


### PR DESCRIPTION
There is a fragment which explicitly states that after `height` command is used turtle should not be shown. It blocks turtle image while stepping. Was there any reason for that check?