### PR TITLE
Fix Python compatibility issue

### DIFF
--- a/src/pyplasm/step.py
+++ b/src/pyplasm/step.py
@@ -54,7 +54,7 @@ class StepAccumulator:
     def reset_history():
         StepAccumulator.geom_base.clear()
         StepAccumulator.pending_actions.clear()
-        StepAccumulator.model_triples.clear()
+        del StepAccumulator.model_triples[:]
 
     @staticmethod
     def forward_one_step(step_id):


### PR DESCRIPTION
For Python v3.4 .clear method can be used clear a list
but in v3.2 (used in production) this method still does not exist.